### PR TITLE
[Bug] Fix SVG files routed to vision pipeline on DashScope

### DIFF
--- a/src/marginalia/pipelines/image.py
+++ b/src/marginalia/pipelines/image.py
@@ -133,7 +133,6 @@ IMAGE_PIPELINE_SCHEMA: dict[str, Any] = {}
 
 @register_pipeline(
     mimes=("image/png", "image/jpeg", "image/jpg", "image/gif", "image/webp"),
-    mime_prefixes=("image/",),
     exts=(".png", ".jpg", ".jpeg", ".gif", ".webp"),
 )
 class ImagePipeline(Pipeline):


### PR DESCRIPTION
Closes #6.

SVG files (`image/svg+xml`) were matched by the overly broad `mime_prefixes=("image/",)` and sent to the vision LLM as base64 PNG data URLs. Since SVG is XML, not raster, DashScope returns "image format is illegal".

Removes the `mime_prefixes` line — the `mimes` tuple already covers all supported raster formats.