### PR TITLE
skills: add metadata and one-shot command references

### DIFF
--- a/skills/README.md
+++ b/skills/README.md
@@ -1,9 +1,10 @@
 # Marginalia skills
 
 Three workflow-oriented skills for any LLM that drives the Marginalia
-CLI (Claude Code, Cursor, etc.). Skills are progressive-disclosure
+CLI (Claude Code, Cursor, pi, etc.). Skills are progressive-disclosure
 instructions — the agent loads the relevant one when the user's intent
-matches the description.
+matches the description. Each skill declares `allowed-tools` and
+`compatibility` in its frontmatter, per the Agent Skills standard.
 
 ## Layout
 
@@ -14,19 +15,22 @@ skills/
 └── discover-and-curate/SKILL.md    # explore relations, build lists
 ```
 
-## Installing into Claude Code
+## Installing into Claude Code / pi
 
-Either copy or symlink each directory into your Claude skills root:
+Either copy or symlink each directory into your agent's skills root:
 
 ```bash
-# Linux/macOS
+# Linux/macOS — Claude Code
 ln -s "$(pwd)/skills/ingest-vault" ~/.claude/skills/ingest-vault
+
+# pi
+ln -s "$(pwd)/skills/ingest-vault" ~/.pi/agent/skills/ingest-vault
 
 # Windows (run as administrator for symlinks, or just copy the folder)
 mklink /D "%USERPROFILE%\.claude\skills\ingest-vault" "%CD%\skills\ingest-vault"
 ```
 
-Then re-launch Claude Code so it picks up the new skill descriptions.
+Then re-launch the agent so it picks up the new skill descriptions.
 
 ## Skills and MCP
 
@@ -53,3 +57,9 @@ Do not hard-code the desktop port in a skill. Packaged desktop builds may use
 
 The MCP server follows the same order. If no running backend is discovered, it
 starts an embedded backend in the MCP process, matching the CLI fallback.
+
+## One-shot commands
+
+Each skill includes a **One-shot commands** section listing the equivalent
+`marginalia ...` invocations that an external agent can run via `bash`
+without entering the REPL. Use `--json` for machine-parseable output.

--- a/skills/discover-and-curate/SKILL.md
+++ b/skills/discover-and-curate/SKILL.md
@@ -1,6 +1,8 @@
 ---
 name: discover-and-curate
 description: Find related entries to a seed file, build reading lists, and surface neighbour clusters Marginalia has discovered automatically. Use when the user is browsing rather than asking a specific question.
+compatibility: Requires the `marginalia` CLI (Python 3.11+), a configured LLM profile for relation vetting, and pre-ingested files. Relation mining needs at least one maintenance pass to produce results; new corpora have sparse relations initially.
+allowed-tools: bash read write
 ---
 
 # Discover and curate
@@ -120,3 +122,21 @@ Reports the status of that specific run.
 
 - **Repeated noise in unvetted results.** That's why vetting exists.
   Drop `--all` and let the LLM filter.
+
+## One-shot commands
+
+All of the above can be driven non-interactively by an external agent:
+
+```bash
+marginalia search "consensus protocols" --json
+marginalia info <full_entry_id> --json
+marginalia discover <full_entry_id> --json
+marginalia discover <full_entry_id> --top-k 12 --json
+marginalia download <entry_id> [dest]
+marginalia tend
+marginalia background --json
+```
+
+Add `--json` for machine-parseable output. The CLI auto-discovers the backend
+like the REPL. One-shot CLI requires **full UUIDs** — the 8-char prefix
+shorthand from REPL mode does not work.

--- a/skills/ingest-vault/SKILL.md
+++ b/skills/ingest-vault/SKILL.md
@@ -1,6 +1,8 @@
 ---
 name: ingest-vault
 description: Bulk-admit files from a Marginalia mirror vault into the database, then let the LLM pipeline catch up in the background. Use when the user has dropped a stack of PDFs / markdown / notes into their vault directory and wants them indexed and searchable.
+compatibility: Requires the `marginalia` CLI (Python 3.11+), a configured LLM ingest profile, and STORAGE_BACKEND=mirror for bulk ingest. For STORAGE_BACKEND=local, use `marginalia upload` per file instead.
+allowed-tools: bash read
 ---
 
 # Ingest a vault into Marginalia
@@ -101,3 +103,20 @@ Once `N busy` settles back near zero, the corpus is ready for:
 
 - **search-by-question** → see `research-with-marginalia` skill
 - **discovery / related-entries** → see `discover-and-curate` skill
+
+## One-shot commands
+
+All of the above can be driven non-interactively by an external agent:
+
+```bash
+marginalia check --json
+marginalia ingest --all --yes --json
+marginalia ingest path/to/folder --yes --json
+marginalia background --json
+marginalia reprocess failed --json
+marginalia reprocess folder <full_folder_id> failed --json
+marginalia upload ./somewhere/paper.pdf /papers/
+```
+
+Add `--json` for machine-parseable output. `--yes` skips confirmation prompts.
+The CLI auto-discovers the backend like the REPL. IDs must be **full UUIDs**.

--- a/skills/research-with-marginalia/SKILL.md
+++ b/skills/research-with-marginalia/SKILL.md
@@ -1,6 +1,8 @@
 ---
 name: research-with-marginalia
 description: Ask Marginalia a research question, follow the citations it returns, and export the result as a single markdown file or a self-contained zip. Use when the user wants to think with their corpus rather than just look up a file.
+compatibility: Requires the `marginalia` CLI (Python 3.11+), a configured LLM chat profile, and pre-ingested files.
+allowed-tools: bash read write
 ---
 
 # Research with Marginalia
@@ -109,3 +111,48 @@ flag it to the user if their question depends on something just added.
   conversation only counts as "ended" once the agent has finished a
   turn. If the user just asked a question and immediately ran /export,
   wait for the answer to fully stream.
+
+## Removing entries
+
+There is no `/delete` command. This is intentional — AI does not mutate
+user files directly. To remove an entry:
+
+1. Delete the file from the mirror vault.
+2. Run `/ingest --all`. Marginalia detects the missing file and
+   soft-deletes the entry (sets `deleted_at`).
+
+The `lifecycle` field (active / demoted / archived) can demote entries
+out of default search results without deleting them. Set
+`AUTO_LIFECYCLE_ENABLED=true` for automatic lifecycle suggestions.
+
+## One-shot commands
+
+All of the above can be driven non-interactively by an external agent:
+
+```bash
+marginalia ask "compare this Raft paper with my Paxos notes"
+marginalia ask "..." --mode quick
+marginalia search "consensus protocols" --json
+marginalia info <full_entry_id> --json
+marginalia discover <full_entry_id> --json
+marginalia download <entry_id> [dest]
+marginalia export <full_conv_id> [dest.md|dest.zip]
+marginalia check --json
+marginalia background --json
+```
+
+Add `--json` for machine-parseable output. Omit it for human-readable text.
+`--server URL` (or `MARGINALIA_SERVER`) connects to a remote backend;
+otherwise the CLI auto-discovers a running `marginalia serve` / desktop
+sidecar, or starts an embedded backend.
+
+One-shot CLI requires **full UUIDs** (e.g. `marginalia info b123a833-...`).
+The 8-char prefix shorthand described in the REPL workflow above does not
+work outside the REPL.
+
+`marginalia export` requires a persistent backend (`marginalia serve` or
+desktop). Two separate embedded-mode invocations (e.g. `marginalia ask` then
+`marginalia export`) do not share state — the first process exits and its
+conversations are gone. Export works inside the REPL because the embedded
+backend stays alive across turns. When passing a conversation id, use the
+**full UUID** — prefix shorthand does not work in one-shot mode.


### PR DESCRIPTION
## Summary

- Add `allowed-tools` and `compatibility` frontmatter to the bundled skills.
- Add one-shot CLI command sections for external agents that do not enter the REPL.
- Clarify that one-shot commands require full UUIDs rather than REPL prefix shorthand.
- Document the mirror-vault removal flow instead of a direct `/delete` command.
- Note that conversation export requires a persistent backend because separate embedded one-shot invocations do not share session state.

## Validation

- Not run; documentation-only changes.