### PR TITLE
desktop: add folder upload filters and resizable library sidebar

### DIFF
--- a/desktop/src/components/library/Dialogs.tsx
+++ b/desktop/src/components/library/Dialogs.tsx
@@ -7,12 +7,12 @@
  *                       and recreates the subfolder structure under the
  *                       target via /v1/folders before uploading each file.
  */
-import { useEffect, useRef, useState } from "react";
+import { useEffect, useMemo, useRef, useState } from "react";
 import { X, Upload, FolderPlus, Loader2 } from "lucide-react";
 
 import { folders as foldersApi, uploads, ApiError, settings as settingsApi } from "@/api/client";
 import type { OnConflict } from "@/types/api";
-import { cn } from "@/lib/utils";
+import { cn, formatBytes } from "@/lib/utils";
 import { useI18n } from "@/lib/i18n";
 
 export function NewFolderDialog({ parentId, parentName, onClose, onCreated }: {
@@ -87,6 +87,35 @@ interface UploadItem {
   renamedTo?: string;
 }
 
+type UploadCategory =
+  | "documents"
+  | "pdfs"
+  | "images"
+  | "archives"
+  | "audio"
+  | "videos"
+  | "unknown";
+
+interface UploadGroup {
+  category: UploadCategory;
+  files: number;
+  bytes: number;
+  selectedFiles: number;
+  selectedBytes: number;
+  extensions: { ext: string; files: number; bytes: number }[];
+}
+
+const CATEGORY_ORDER: UploadCategory[] = [
+  "documents",
+  "pdfs",
+  "images",
+  "archives",
+  "audio",
+  "videos",
+  "unknown",
+];
+const DEFAULT_INCLUDED_CATEGORIES = CATEGORY_ORDER.filter((c) => c !== "videos");
+
 export function UploadDialog({ folderId, folderName, onClose, onUploaded }: {
   folderId: string | null;
   folderName: string;
@@ -99,6 +128,12 @@ export function UploadDialog({ folderId, folderName, onClose, onUploaded }: {
   const [running, setRunning] = useState(false);
   const [scanning, setScanning] = useState(false);
   const [dragOver, setDragOver] = useState(false);
+  const [includedCategories, setIncludedCategories] = useState<Set<UploadCategory>>(
+    () => new Set(DEFAULT_INCLUDED_CATEGORIES),
+  );
+  const [excludedExtensions, setExcludedExtensions] = useState<Set<string>>(
+    () => new Set(),
+  );
   const fileInput = useRef<HTMLInputElement>(null);
 
   // Seed conflict policy from the server's current default so what the
@@ -122,6 +157,36 @@ export function UploadDialog({ folderId, folderName, onClose, onUploaded }: {
 
   const addItems = (next: UploadItem[]) => {
     setItems((prev) => [...prev, ...next]);
+  };
+
+  const uploadPlan = useMemo(
+    () => summarizeUploadPlan(items, includedCategories, excludedExtensions),
+    [items, includedCategories, excludedExtensions],
+  );
+
+  const hasQueuedSelected = items.some(
+    (it) => it.status === "queued"
+      && shouldUploadItem(it, includedCategories, excludedExtensions),
+  );
+
+  const toggleCategory = (category: UploadCategory) => {
+    if (running) return;
+    setIncludedCategories((prev) => {
+      const next = new Set(prev);
+      if (next.has(category)) next.delete(category);
+      else next.add(category);
+      return next;
+    });
+  };
+
+  const toggleExtension = (ext: string) => {
+    if (running) return;
+    setExcludedExtensions((prev) => {
+      const next = new Set(prev);
+      if (next.has(ext)) next.delete(ext);
+      else next.add(ext);
+      return next;
+    });
   };
 
   const onPickFiles = (fs: FileList | File[]) => {
@@ -170,6 +235,7 @@ export function UploadDialog({ folderId, folderName, onClose, onUploaded }: {
     folderCache.set("", folderId);
     for (let i = 0; i < items.length; i++) {
       if (items[i].status !== "queued") continue;
+      if (!shouldUploadItem(items[i], includedCategories, excludedExtensions)) continue;
       setItems((p) => updateAt(p, i, { status: "uploading" }));
       try {
         const targetFolderId = await mkdirP(folderCache, items[i].relDirs);
@@ -243,8 +309,49 @@ export function UploadDialog({ folderId, folderName, onClose, onUploaded }: {
       </p>
 
       {items.length > 0 && (
+        <div className="mt-3 rounded-md border border-border bg-bg-subtle p-3 text-xs">
+          <div className="flex items-center justify-between gap-3">
+            <span className="font-medium text-fg-base">{t.dialogs.uploadFilterTitle}</span>
+            <span className="shrink-0 text-fg-muted">
+              {t.dialogs.uploadPlan(uploadPlan.selectedFiles, uploadPlan.skippedFiles)}
+            </span>
+          </div>
+          {uploadPlan.skippedFiles > 0 && (
+            <p className="mt-1 text-fg-muted">
+              {t.dialogs.uploadSkippedSummary(
+                uploadPlan.skippedFiles,
+                formatBytes(uploadPlan.skippedBytes),
+              )}
+            </p>
+          )}
+          <div className="mt-3 grid grid-cols-1 gap-2 sm:grid-cols-2">
+            {uploadPlan.groups.map((group) => (
+              <FilterGroupCard
+                key={group.category}
+                group={group}
+                checked={includedCategories.has(group.category)}
+                excludedExtensions={excludedExtensions}
+                disabled={running}
+                onToggleCategory={toggleCategory}
+                onToggleExtension={toggleExtension}
+              />
+            ))}
+          </div>
+        </div>
+      )}
+
+      {items.length > 0 && (
         <ul className="mt-3 max-h-64 space-y-1 overflow-y-auto rounded-md border border-border bg-bg-subtle p-2 text-xs">
-          {items.map((it, i) => <UploadRow key={i} item={it} />)}
+          {items.map((it, i) => (
+            <UploadRow
+              key={i}
+              item={it}
+              skipped={
+                it.status === "queued"
+                && !shouldUploadItem(it, includedCategories, excludedExtensions)
+              }
+            />
+          ))}
         </ul>
       )}
 
@@ -255,10 +362,10 @@ export function UploadDialog({ folderId, folderName, onClose, onUploaded }: {
         </button>
         <button
           onClick={start}
-          disabled={running || items.every((it) => it.status !== "queued")}
+          disabled={running || !hasQueuedSelected}
           className={cn(
             "flex items-center gap-1 rounded-md px-3 py-1.5 text-sm font-medium",
-            running || items.every((it) => it.status !== "queued")
+            running || !hasQueuedSelected
               ? "cursor-not-allowed bg-bg-muted text-fg-subtle"
               : "bg-accent text-accent-fg hover:opacity-90",
           )}
@@ -271,7 +378,74 @@ export function UploadDialog({ folderId, folderName, onClose, onUploaded }: {
   );
 }
 
-function UploadRow({ item }: { item: UploadItem }) {
+function FilterGroupCard({
+  group,
+  checked,
+  excludedExtensions,
+  disabled,
+  onToggleCategory,
+  onToggleExtension,
+}: {
+  group: UploadGroup;
+  checked: boolean;
+  excludedExtensions: Set<string>;
+  disabled: boolean;
+  onToggleCategory: (category: UploadCategory) => void;
+  onToggleExtension: (ext: string) => void;
+}) {
+  const { t } = useI18n();
+  return (
+    <div className="rounded-md border border-border bg-bg-base p-2">
+      <label className="flex cursor-pointer items-start gap-2">
+        <input
+          type="checkbox"
+          checked={checked}
+          disabled={disabled}
+          onChange={() => onToggleCategory(group.category)}
+          className="mt-0.5 accent-accent"
+        />
+        <span className="min-w-0 flex-1">
+          <span className="block font-medium text-fg-base">
+            {t.dialogs.uploadCategories[group.category]}
+          </span>
+          <span className="block text-fg-muted">
+            {t.dialogs.uploadCategorySummary(group.files, formatBytes(group.bytes))}
+          </span>
+        </span>
+      </label>
+      {group.extensions.length > 0 && (
+        <div className="mt-2 flex flex-wrap gap-1">
+          {group.extensions.map((ext) => {
+            const excluded = excludedExtensions.has(ext.ext);
+            return (
+              <button
+                key={ext.ext}
+                type="button"
+                disabled={disabled}
+                onClick={() => onToggleExtension(ext.ext)}
+                title={
+                  excluded
+                    ? t.dialogs.uploadIncludeExtension(ext.ext)
+                    : t.dialogs.uploadExcludeExtension(ext.ext)
+                }
+                className={cn(
+                  "rounded border px-1.5 py-0.5 text-[11px]",
+                  excluded
+                    ? "border-danger/50 bg-danger/10 text-danger"
+                    : "border-border text-fg-muted hover:border-accent hover:text-accent",
+                )}
+              >
+                {ext.ext} {ext.files}
+              </button>
+            );
+          })}
+        </div>
+      )}
+    </div>
+  );
+}
+
+function UploadRow({ item, skipped }: { item: UploadItem; skipped: boolean }) {
   const { t } = useI18n();
   const pct = item.file.size > 0 ? Math.round((item.loaded / item.file.size) * 100) : 0;
   const prefix = item.relDirs.length ? item.relDirs.join("/") + "/" : "";
@@ -283,9 +457,10 @@ function UploadRow({ item }: { item: UploadItem }) {
       </span>
       <span className="w-12 text-right text-fg-subtle">
         {item.status === "uploading" ? `${pct}%`
-         : item.status === "done" ? "✓"
+         : item.status === "done" ? "done"
          : item.status === "error" ? "!"
-         : "—"}
+         : skipped ? t.dialogs.skipped
+         : "-"}
       </span>
       {item.renamedTo && (
         <span className="truncate text-fg-subtle" title={t.dialogs.renamedTo(item.renamedTo)}>
@@ -304,6 +479,147 @@ function updateAt<T>(arr: T[], i: number, patch: Partial<T>): T[] {
   next[i] = { ...next[i], ...patch };
   return next;
 }
+
+function summarizeUploadPlan(
+  items: UploadItem[],
+  includedCategories: Set<UploadCategory>,
+  excludedExtensions: Set<string>,
+) {
+  const groups = new Map<UploadCategory, UploadGroup>();
+  let selectedFiles = 0;
+  let selectedBytes = 0;
+  let skippedFiles = 0;
+  let skippedBytes = 0;
+
+  for (const category of CATEGORY_ORDER) {
+    groups.set(category, {
+      category,
+      files: 0,
+      bytes: 0,
+      selectedFiles: 0,
+      selectedBytes: 0,
+      extensions: [],
+    });
+  }
+
+  const extMaps = new Map<UploadCategory, Map<string, { files: number; bytes: number }>>();
+  for (const item of items) {
+    const category = categoryForFile(item.file);
+    const ext = extensionForFile(item.file);
+    const group = groups.get(category)!;
+    group.files += 1;
+    group.bytes += item.file.size;
+    if (!extMaps.has(category)) extMaps.set(category, new Map());
+    const extMap = extMaps.get(category)!;
+    const extStat = extMap.get(ext) ?? { files: 0, bytes: 0 };
+    extStat.files += 1;
+    extStat.bytes += item.file.size;
+    extMap.set(ext, extStat);
+
+    if (shouldUploadItem(item, includedCategories, excludedExtensions)) {
+      selectedFiles += 1;
+      selectedBytes += item.file.size;
+      group.selectedFiles += 1;
+      group.selectedBytes += item.file.size;
+    } else {
+      skippedFiles += 1;
+      skippedBytes += item.file.size;
+    }
+  }
+
+  for (const [category, extMap] of extMaps) {
+    const group = groups.get(category)!;
+    group.extensions = [...extMap.entries()]
+      .map(([ext, stat]) => ({ ext, ...stat }))
+      .sort((a, b) => b.files - a.files || a.ext.localeCompare(b.ext));
+  }
+
+  return {
+    groups: CATEGORY_ORDER.map((category) => groups.get(category)!)
+      .filter((group) => group.files > 0),
+    selectedFiles,
+    selectedBytes,
+    skippedFiles,
+    skippedBytes,
+  };
+}
+
+function shouldUploadItem(
+  item: UploadItem,
+  includedCategories: Set<UploadCategory>,
+  excludedExtensions: Set<string>,
+): boolean {
+  const category = categoryForFile(item.file);
+  const ext = extensionForFile(item.file);
+  return includedCategories.has(category) && !excludedExtensions.has(ext);
+}
+
+function categoryForFile(file: File): UploadCategory {
+  const mime = (file.type || "").toLowerCase();
+  const ext = extensionForFile(file);
+  if (mime === "application/pdf" || ext === ".pdf") return "pdfs";
+  if (mime.startsWith("video/") || VIDEO_EXTENSIONS.has(ext)) return "videos";
+  if (mime.startsWith("audio/") || AUDIO_EXTENSIONS.has(ext)) return "audio";
+  if (mime.startsWith("image/") || IMAGE_EXTENSIONS.has(ext)) return "images";
+  if (ARCHIVE_EXTENSIONS.has(ext) || ARCHIVE_MIMES.has(mime)) return "archives";
+  if (
+    mime.startsWith("text/")
+    || DOCUMENT_EXTENSIONS.has(ext)
+    || DOCUMENT_MIMES.has(mime)
+  ) {
+    return "documents";
+  }
+  return "unknown";
+}
+
+function extensionForFile(file: File): string {
+  const idx = file.name.lastIndexOf(".");
+  if (idx <= 0 || idx === file.name.length - 1) return "(none)";
+  return file.name.slice(idx).toLowerCase();
+}
+
+const VIDEO_EXTENSIONS = new Set([
+  ".3gp", ".avi", ".flv", ".m4v", ".mkv", ".mov", ".mp4", ".mpeg",
+  ".mpg", ".webm", ".wmv",
+]);
+const AUDIO_EXTENSIONS = new Set([
+  ".aac", ".aiff", ".flac", ".m4a", ".mp3", ".oga", ".ogg", ".opus",
+  ".wav", ".wma",
+]);
+const IMAGE_EXTENSIONS = new Set([
+  ".avif", ".bmp", ".gif", ".heic", ".heif", ".jpeg", ".jpg", ".png",
+  ".svg", ".tif", ".tiff", ".webp",
+]);
+const ARCHIVE_EXTENSIONS = new Set([
+  ".7z", ".bz2", ".gz", ".rar", ".tar", ".tgz", ".xz", ".zip",
+]);
+const DOCUMENT_EXTENSIONS = new Set([
+  ".bat", ".c", ".cpp", ".csv", ".doc", ".docx", ".go", ".h", ".hpp",
+  ".htm", ".html", ".java", ".js", ".json", ".jsx", ".kt", ".log",
+  ".md", ".odf", ".ods", ".odt", ".php", ".ppt", ".pptx", ".ps1",
+  ".py", ".rb", ".rs", ".rst", ".rtf", ".scala", ".sh", ".sql",
+  ".swift", ".tex", ".toml", ".ts", ".tsx", ".txt", ".xls", ".xlsx",
+  ".xml", ".yaml", ".yml",
+]);
+const ARCHIVE_MIMES = new Set([
+  "application/gzip",
+  "application/vnd.rar",
+  "application/x-7z-compressed",
+  "application/x-bzip2",
+  "application/x-tar",
+  "application/zip",
+]);
+const DOCUMENT_MIMES = new Set([
+  "application/json",
+  "application/msword",
+  "application/rtf",
+  "application/vnd.ms-excel",
+  "application/vnd.ms-powerpoint",
+  "application/vnd.openxmlformats-officedocument.presentationml.presentation",
+  "application/vnd.openxmlformats-officedocument.spreadsheetml.sheet",
+  "application/vnd.openxmlformats-officedocument.wordprocessingml.document",
+  "application/xml",
+]);
 
 function ModalShell({ title, onClose, children, wide }: {
   title: React.ReactNode;

--- a/desktop/src/lib/i18n.ts
+++ b/desktop/src/lib/i18n.ts
@@ -170,6 +170,7 @@ const en = {
       "Select a file from the tree to preview it. Click here to deselect.",
     emptyHint:
       "Select or create a folder to start. Files appear under their folder.",
+    resizeSidebar: "Drag to resize the library sidebar",
     reprocessFolderConfirm: (name: string) =>
       `Re-run AI analysis on every file in "${name}" and its subfolders?`,
     reprocessAllConfirm:
@@ -255,6 +256,25 @@ const en = {
     },
     uploadAnalysisHint:
       "After upload, watch the bottom Activity button or Library status badges until AI analysis finishes. Failed files can be retried.",
+    uploadFilterTitle: "Import filter",
+    uploadPlan: (selected: number, skipped: number) =>
+      `${selected} to upload · ${skipped} skipped`,
+    uploadSkippedSummary: (files: number, size: string) =>
+      `Skipping ${files} file(s), ${size}.`,
+    uploadCategories: {
+      documents: "Documents",
+      pdfs: "PDFs",
+      images: "Images",
+      archives: "Archives",
+      audio: "Audio",
+      videos: "Videos",
+      unknown: "Unknown",
+    },
+    uploadCategorySummary: (files: number, size: string) =>
+      `${files} file(s) · ${size}`,
+    uploadExcludeExtension: (ext: string) => `Skip ${ext}`,
+    uploadIncludeExtension: (ext: string) => `Include ${ext}`,
+    skipped: "skip",
     start: "Start",
     uploading: "Uploading...",
     renamedTo: (name: string) => `renamed to ${name}`,
@@ -756,6 +776,7 @@ const zh: I18nStrings = {
     selectFileTitle: (folderName: string | null) => folderName || "资料库",
     selectFileHint: "从左侧树中选择文件以预览。点击这里取消选择。",
     emptyHint: "选择或创建一个文件夹开始。文件会显示在所属文件夹下。",
+    resizeSidebar: "拖拽调整资料库侧栏宽度",
     reprocessFolderConfirm: (name: string) =>
       `重新对 "${name}" 及其子文件夹中的所有文件运行 AI 分析？`,
     reprocessAllConfirm:
@@ -841,6 +862,25 @@ const zh: I18nStrings = {
     },
     uploadAnalysisHint:
       "上传完成后，请关注底部后台任务按钮或资料库状态标记，等待 AI 分析完成；失败文件可以重试。",
+    uploadFilterTitle: "导入过滤",
+    uploadPlan: (selected: number, skipped: number) =>
+      `将上传 ${selected} 个 · 跳过 ${skipped} 个`,
+    uploadSkippedSummary: (files: number, size: string) =>
+      `已跳过 ${files} 个文件，${size}。`,
+    uploadCategories: {
+      documents: "文档",
+      pdfs: "PDF",
+      images: "图片",
+      archives: "压缩包",
+      audio: "音频",
+      videos: "视频",
+      unknown: "未知",
+    },
+    uploadCategorySummary: (files: number, size: string) =>
+      `${files} 个文件 · ${size}`,
+    uploadExcludeExtension: (ext: string) => `跳过 ${ext}`,
+    uploadIncludeExtension: (ext: string) => `包含 ${ext}`,
+    skipped: "跳过",
     start: "开始",
     uploading: "上传中...",
     renamedTo: (name: string) => `已重命名为 ${name}`,

--- a/desktop/src/pages/LibraryPage.tsx
+++ b/desktop/src/pages/LibraryPage.tsx
@@ -9,7 +9,14 @@
  *  - Background ingest tasks are reflected by spinners on the matching file rows
  *    via a single 4 s poll of /v1/tasks/active
  */
-import { useCallback, useEffect, useMemo, useRef, useState } from "react";
+import {
+  useCallback,
+  useEffect,
+  useMemo,
+  useRef,
+  useState,
+  type PointerEvent as ReactPointerEvent,
+} from "react";
 import { useSearchParams } from "react-router-dom";
 import { Inbox } from "lucide-react";
 
@@ -20,6 +27,11 @@ import { FileViewer } from "@/components/library/FileViewer";
 import { MetaPanel } from "@/components/library/MetaPanel";
 import { NewFolderDialog, UploadDialog } from "@/components/library/Dialogs";
 import { useI18n, type I18nStrings } from "@/lib/i18n";
+
+const SIDEBAR_WIDTH_KEY = "marginalia.library.sidebarWidth";
+const SIDEBAR_DEFAULT_WIDTH = 288;
+const SIDEBAR_MIN_WIDTH = 240;
+const SIDEBAR_MAX_WIDTH = 560;
 
 export function LibraryPage() {
   const [searchParams, setSearchParams] = useSearchParams();
@@ -51,6 +63,8 @@ export function LibraryPage() {
   const [uploadInto, setUploadInto] = useState<{ id: string | null; name: string } | null>(null);
 
   const [active, setActive] = useState<ActiveTasks | null>(null);
+  const sidebarRef = useRef<HTMLDivElement>(null);
+  const [sidebarWidth, setSidebarWidth] = useState(readSidebarWidth);
   const ingestingFileIds = useMemo<Set<string>>(() => {
     const set = new Set<string>();
     if (!active) return set;
@@ -162,9 +176,39 @@ export function LibraryPage() {
   const headerTargetFolderId = selectedFolder?.id ?? null;
   const headerTargetName = selectedFolder?.name ?? t.library.root;
 
+  const startSidebarResize = useCallback((e: ReactPointerEvent<HTMLDivElement>) => {
+    e.preventDefault();
+    const left = sidebarRef.current?.parentElement?.getBoundingClientRect().left ?? 0;
+    const prevCursor = document.body.style.cursor;
+    const prevUserSelect = document.body.style.userSelect;
+    document.body.style.cursor = "col-resize";
+    document.body.style.userSelect = "none";
+
+    const onMove = (event: PointerEvent) => {
+      const next = clampSidebarWidth(event.clientX - left);
+      setSidebarWidth(next);
+      window.localStorage.setItem(SIDEBAR_WIDTH_KEY, String(next));
+    };
+    const onUp = () => {
+      document.body.style.cursor = prevCursor;
+      document.body.style.userSelect = prevUserSelect;
+      window.removeEventListener("pointermove", onMove);
+      window.removeEventListener("pointerup", onUp);
+      window.removeEventListener("pointercancel", onUp);
+    };
+
+    window.addEventListener("pointermove", onMove);
+    window.addEventListener("pointerup", onUp);
+    window.addEventListener("pointercancel", onUp);
+  }, []);
+
   return (
     <div className="flex h-full">
-      <div className="w-72 shrink-0 border-r border-border bg-bg-base">
+      <div
+        ref={sidebarRef}
+        className="shrink-0 border-r border-border bg-bg-base"
+        style={{ width: sidebarWidth }}
+      >
         <FolderTree
           selectedEntryId={selectedEntry?.id || null}
           selectedFolderId={selectedFolder?.id || null}
@@ -199,6 +243,16 @@ export function LibraryPage() {
           }}
           onClearSelection={clearSelection}
         />
+      </div>
+      <div
+        role="separator"
+        aria-orientation="vertical"
+        aria-label={t.library.resizeSidebar}
+        title={t.library.resizeSidebar}
+        onPointerDown={startSidebarResize}
+        className="group relative z-10 w-1 shrink-0 cursor-col-resize bg-bg-base hover:bg-accent/10"
+      >
+        <div className="absolute inset-y-0 left-1/2 w-px -translate-x-1/2 bg-border group-hover:bg-accent" />
       </div>
 
       <main className="flex flex-1 overflow-hidden bg-bg-base">
@@ -245,6 +299,17 @@ function activeTaskFileIds(active: ActiveTasks): Set<string> {
   for (const task of active.running) if (task.file_id) ids.add(task.file_id);
   for (const task of active.pending) if (task.file_id) ids.add(task.file_id);
   return ids;
+}
+
+function readSidebarWidth(): number {
+  if (typeof window === "undefined") return SIDEBAR_DEFAULT_WIDTH;
+  const raw = window.localStorage.getItem(SIDEBAR_WIDTH_KEY);
+  const parsed = raw ? Number(raw) : NaN;
+  return clampSidebarWidth(Number.isFinite(parsed) ? parsed : SIDEBAR_DEFAULT_WIDTH);
+}
+
+function clampSidebarWidth(width: number): number {
+  return Math.min(SIDEBAR_MAX_WIDTH, Math.max(SIDEBAR_MIN_WIDTH, Math.round(width)));
 }
 
 function EmptyViewer({


### PR DESCRIPTION
## Summary

- Add an import filter to the Library upload dialog after files/folders are scanned.
- Group pending uploads by type and extension, with Videos disabled by default so large video files are skipped before upload/ingest tasks are created.
- Let users include/exclude whole file-type groups or individual extension chips without a glob-pattern text box.
- Add a draggable Library sidebar separator and persist the chosen width in localStorage.

## Validation

- `npm run lint` in `desktop`