### PR TITLE
Release v0.2.7

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,46 @@
 
 ## Unreleased
 
+## 0.2.7 - 2026-06-19
+
+### Added
+
+- Desktop folder uploads now show an import filter after scanning files and
+  folders. Videos are skipped by default, and users can include or exclude
+  whole file-type groups or individual extension chips before upload creates
+  files or ingest tasks.
+- The desktop Library sidebar can now be resized by dragging the separator,
+  with the chosen width saved locally.
+- Bundled agent skills now include `allowed-tools` / `compatibility` metadata
+  and one-shot CLI command references for agents that do not enter the REPL.
+
+### Changed
+
+- `/v1/discover` is now a pure read path by default; seed-scoped relation
+  vetting runs only when explicitly requested via `vet=true` / `--vet` and is
+  scheduled in the background.
+- Task runner settings are refreshed dynamically so runtime configuration
+  updates are picked up without restarting long-lived workers.
+
+### Fixed
+
+- Desktop navigation now uses hash routing in Tauri, avoiding full webview
+  reloads and repeated cold API calls while moving between Chat and Library.
+- The desktop Library now exposes failed-only reprocess actions globally and
+  per folder while keeping full-scope reprocess available.
+- Empty agent execute responses after planning now surface as explicit errors
+  instead of silent zero-token answers.
+- Resumed tool results use the expected message roles.
+- Duplicate ingest tag attachments are de-duplicated before insert, avoiding
+  `entry_tags(entry_id, tag_id)` uniqueness failures.
+- Discover relation vetting skips detail queries when there are no candidates.
+
+### Documentation
+
+- Documented PDF and image indexing budgets, chunking behavior, OCR caps,
+  embedded PDF image caption limits, standalone image ingest limits, and PDF
+  read-time windows in English and Chinese usage docs.
+
 ## 0.2.6 - 2026-06-19
 
 ### Added

--- a/desktop/package-lock.json
+++ b/desktop/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "marginalia-desktop",
-  "version": "0.2.6",
+  "version": "0.2.7",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "marginalia-desktop",
-      "version": "0.2.6",
+      "version": "0.2.7",
       "dependencies": {
         "@tauri-apps/api": "^2.1.1",
         "@types/react-syntax-highlighter": "^15.5.13",

--- a/desktop/package.json
+++ b/desktop/package.json
@@ -1,7 +1,7 @@
 {
   "name": "marginalia-desktop",
   "private": true,
-  "version": "0.2.6",
+  "version": "0.2.7",
   "type": "module",
   "description": "Marginalia desktop GUI — Tauri + React + Vite",
   "scripts": {

--- a/desktop/src-tauri/Cargo.lock
+++ b/desktop/src-tauri/Cargo.lock
@@ -2078,7 +2078,7 @@ dependencies = [
 
 [[package]]
 name = "marginalia-tauri"
-version = "0.2.6"
+version = "0.2.7"
 dependencies = [
  "log",
  "serde",

--- a/desktop/src-tauri/Cargo.toml
+++ b/desktop/src-tauri/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "marginalia-tauri"
-version = "0.2.6"
+version = "0.2.7"
 description = "Marginalia desktop shell"
 authors = ["Marginalia"]
 license = ""

--- a/desktop/src-tauri/tauri.conf.json
+++ b/desktop/src-tauri/tauri.conf.json
@@ -1,7 +1,7 @@
 {
   "$schema": "../node_modules/@tauri-apps/cli/config.schema.json",
   "productName": "Marginalia",
-  "version": "0.2.6",
+  "version": "0.2.7",
   "identifier": "io.marginalia.desktop",
   "build": {
     "frontendDist": "../dist",

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "marginalia"
-version = "0.2.6"
+version = "0.2.7"
 description = "A library-science-inspired personal knowledge management system with LLM agents."
 requires-python = ">=3.11"
 license = "AGPL-3.0-or-later"

--- a/src/marginalia/__init__.py
+++ b/src/marginalia/__init__.py
@@ -1,3 +1,3 @@
 """Marginalia: a library-science-inspired knowledge management system."""
 
-__version__ = "0.2.6"
+__version__ = "0.2.7"


### PR DESCRIPTION
## Summary

- Bump Python, desktop, and Tauri versions to `0.2.7`.
- Add `CHANGELOG.md` release notes for the fixes and desktop UX updates merged after `v0.2.6`.

## Validation

- `npm run lint` in `desktop`
- `python -B -m pytest tests/test_lazy_relation_vetting_e2e.py tests/test_session_resume_e2e.py tests/test_discover_e2e.py tests/test_vet_relations_e2e.py tests/test_reprocess_e2e.py tests/test_ingest_file_unit.py`