### PR TITLE
Fix v0.2.7 uv lock metadata

### DIFF
--- a/uv.lock
+++ b/uv.lock
@@ -1263,7 +1263,7 @@ wheels = [
 
 [[package]]
 name = "marginalia"
-version = "0.2.6"
+version = "0.2.7"
 source = { editable = "." }
 dependencies = [
     { name = "aioboto3" },


### PR DESCRIPTION
## Summary

- Update the editable `marginalia` package version in `uv.lock` from `0.2.6` to `0.2.7` after the release version bump.

## Root cause

`pyproject.toml` was bumped in #22, but `uv.lock` still described the local editable project as `0.2.6`, so CI failed at `uv sync --locked --extra dev` with "The lockfile needs to be updated".

## Validation

- `uv lock --check`

Note: local `uv sync --locked --extra dev` no longer fails on lock mismatch, but the full install timed out locally while syncing packages.