### PR TITLE
Fix stale ingest status and refine upload filters

### DIFF
--- a/alembic/versions/0013_reconcile_dead_ingest_files.py
+++ b/alembic/versions/0013_reconcile_dead_ingest_files.py
@@ -1,0 +1,29 @@
+"""reconcile files left active after dead ingest tasks
+
+Revision ID: 0013_reconcile_dead_ingest_files
+Revises: 0012_journal_invalidation
+Create Date: 2026-06-19
+
+Older workers could mark an ingest_file task dead after an exception or stale
+lease without mirroring that terminal state to files.ingest_status. This data
+repair is idempotent and only touches files that have no active ingest task.
+"""
+from __future__ import annotations
+
+from alembic import op
+
+from marginalia.db.bootstrap import _reconcile_dead_ingest_files
+
+
+revision = "0013_reconcile_dead_ingest_files"
+down_revision = "0012_journal_invalidation"
+branch_labels = None
+depends_on = None
+
+
+def upgrade() -> None:
+    _reconcile_dead_ingest_files(op.get_bind())
+
+
+def downgrade() -> None:
+    pass

--- a/desktop/src/components/library/Dialogs.tsx
+++ b/desktop/src/components/library/Dialogs.tsx
@@ -8,7 +8,7 @@
  *                       target via /v1/folders before uploading each file.
  */
 import { useEffect, useMemo, useRef, useState } from "react";
-import { X, Upload, FolderPlus, Loader2 } from "lucide-react";
+import { Filter, X, Upload, FolderPlus, Loader2 } from "lucide-react";
 
 import { folders as foldersApi, uploads, ApiError, settings as settingsApi } from "@/api/client";
 import type { OnConflict } from "@/types/api";
@@ -82,6 +82,7 @@ interface UploadItem {
    *  for a file at <drop>/sub/deep/file.md. Empty for plain file drops. */
   relDirs: string[];
   loaded: number;
+  selected: boolean;
   status: "queued" | "uploading" | "done" | "error";
   err?: string;
   renamedTo?: string;
@@ -102,7 +103,13 @@ interface UploadGroup {
   bytes: number;
   selectedFiles: number;
   selectedBytes: number;
-  extensions: { ext: string; files: number; bytes: number }[];
+  extensions: {
+    ext: string;
+    files: number;
+    bytes: number;
+    selectedFiles: number;
+    selectedBytes: number;
+  }[];
 }
 
 const CATEGORY_ORDER: UploadCategory[] = [
@@ -114,7 +121,9 @@ const CATEGORY_ORDER: UploadCategory[] = [
   "videos",
   "unknown",
 ];
-const DEFAULT_INCLUDED_CATEGORIES = CATEGORY_ORDER.filter((c) => c !== "videos");
+const DEFAULT_INCLUDED_CATEGORIES: UploadCategory[] = CATEGORY_ORDER.filter(
+  (c) => c !== "videos",
+);
 
 export function UploadDialog({ folderId, folderName, onClose, onUploaded }: {
   folderId: string | null;
@@ -128,12 +137,7 @@ export function UploadDialog({ folderId, folderName, onClose, onUploaded }: {
   const [running, setRunning] = useState(false);
   const [scanning, setScanning] = useState(false);
   const [dragOver, setDragOver] = useState(false);
-  const [includedCategories, setIncludedCategories] = useState<Set<UploadCategory>>(
-    () => new Set(DEFAULT_INCLUDED_CATEGORIES),
-  );
-  const [excludedExtensions, setExcludedExtensions] = useState<Set<string>>(
-    () => new Set(),
-  );
+  const [filterOpen, setFilterOpen] = useState(false);
   const fileInput = useRef<HTMLInputElement>(null);
 
   // Seed conflict policy from the server's current default so what the
@@ -160,38 +164,61 @@ export function UploadDialog({ folderId, folderName, onClose, onUploaded }: {
   };
 
   const uploadPlan = useMemo(
-    () => summarizeUploadPlan(items, includedCategories, excludedExtensions),
-    [items, includedCategories, excludedExtensions],
+    () => summarizeUploadPlan(items),
+    [items],
   );
 
   const hasQueuedSelected = items.some(
-    (it) => it.status === "queued"
-      && shouldUploadItem(it, includedCategories, excludedExtensions),
+    (it) => it.status === "queued" && it.selected,
   );
+
+  const toggleAll = () => {
+    if (running) return;
+    const nextSelected = !items.every((item) => item.selected);
+    setItems((prev) => prev.map((item) => (
+      item.status === "queued" ? { ...item, selected: nextSelected } : item
+    )));
+  };
 
   const toggleCategory = (category: UploadCategory) => {
     if (running) return;
-    setIncludedCategories((prev) => {
-      const next = new Set(prev);
-      if (next.has(category)) next.delete(category);
-      else next.add(category);
-      return next;
-    });
+    const group = uploadPlan.groups.find((g) => g.category === category);
+    const nextSelected = !group || group.selectedFiles < group.files;
+    setItems((prev) => prev.map((item) => (
+      item.status === "queued" && categoryForFile(item.file) === category
+        ? { ...item, selected: nextSelected }
+        : item
+    )));
   };
 
-  const toggleExtension = (ext: string) => {
+  const toggleExtension = (category: UploadCategory, ext: string) => {
     if (running) return;
-    setExcludedExtensions((prev) => {
-      const next = new Set(prev);
-      if (next.has(ext)) next.delete(ext);
-      else next.add(ext);
-      return next;
-    });
+    const matching = items.filter(
+      (item) => categoryForFile(item.file) === category && extensionForFile(item.file) === ext,
+    );
+    const selectedCount = matching.filter((item) => item.selected).length;
+    const nextSelected = selectedCount < matching.length;
+    setItems((prev) => prev.map((item) => (
+      item.status === "queued"
+      && categoryForFile(item.file) === category
+      && extensionForFile(item.file) === ext
+        ? { ...item, selected: nextSelected }
+        : item
+    )));
+  };
+
+  const toggleItem = (index: number) => {
+    if (running || items[index]?.status !== "queued") return;
+    setItems((prev) => updateAt(prev, index, { selected: !prev[index].selected }));
   };
 
   const onPickFiles = (fs: FileList | File[]) => {
     addItems(Array.from(fs).map((file) => ({
-      file, relDirs: [], loaded: 0, status: "queued" as const,
+      file,
+      relDirs: [],
+      loaded: 0,
+      selected: DEFAULT_INCLUDED_CATEGORIES.includes(categoryForFile(file)),
+      status: "queued" as const,
     })));
   };
 
@@ -235,7 +262,7 @@ export function UploadDialog({ folderId, folderName, onClose, onUploaded }: {
     folderCache.set("", folderId);
     for (let i = 0; i < items.length; i++) {
       if (items[i].status !== "queued") continue;
-      if (!shouldUploadItem(items[i], includedCategories, excludedExtensions)) continue;
+      if (!items[i].selected) continue;
       setItems((p) => updateAt(p, i, { status: "uploading" }));
       try {
         const targetFolderId = await mkdirP(folderCache, items[i].relDirs);
@@ -309,50 +336,95 @@ export function UploadDialog({ folderId, folderName, onClose, onUploaded }: {
       </p>
 
       {items.length > 0 && (
-        <div className="mt-3 rounded-md border border-border bg-bg-subtle p-3 text-xs">
-          <div className="flex items-center justify-between gap-3">
-            <span className="font-medium text-fg-base">{t.dialogs.uploadFilterTitle}</span>
-            <span className="shrink-0 text-fg-muted">
+        <div className="mt-3 rounded-md border border-border bg-bg-subtle text-xs">
+          <div className="flex flex-wrap items-center gap-2 border-b border-border px-3 py-2">
+            <label className="flex cursor-pointer items-center gap-1.5 text-fg-base">
+              <input
+                type="checkbox"
+                checked={items.length > 0 && items.every((item) => item.selected)}
+                disabled={running}
+                onChange={toggleAll}
+                className="accent-accent"
+              />
+              <span>{t.dialogs.uploadFilterTitle}</span>
+            </label>
+            <span className="text-fg-muted">
               {t.dialogs.uploadPlan(uploadPlan.selectedFiles, uploadPlan.skippedFiles)}
+              {" / "}
+              {formatBytes(uploadPlan.selectedBytes)}
             </span>
+            <div className="ml-auto flex flex-wrap items-center gap-2">
+              {uploadPlan.groups.map((group) => (
+                <CategoryToggle
+                  key={group.category}
+                  group={group}
+                  disabled={running}
+                  onToggle={toggleCategory}
+                />
+              ))}
+              <div className="relative">
+                <button
+                  type="button"
+                  onClick={() => setFilterOpen((open) => !open)}
+                  disabled={running}
+                  title={t.dialogs.uploadFilterTitle}
+                  className={cn(
+                    "rounded p-1 text-fg-muted hover:bg-bg-muted hover:text-fg-base",
+                    filterOpen && "bg-bg-muted text-fg-base",
+                  )}
+                >
+                  <Filter size={14} />
+                </button>
+                {filterOpen && (
+                  <UploadFilterPanel
+                    groups={uploadPlan.groups}
+                    disabled={running}
+                    onToggleCategory={toggleCategory}
+                    onToggleExtension={toggleExtension}
+                  />
+                )}
+              </div>
+            </div>
           </div>
           {uploadPlan.skippedFiles > 0 && (
-            <p className="mt-1 text-fg-muted">
+            <div className="border-b border-border px-3 py-1.5 text-fg-muted">
               {t.dialogs.uploadSkippedSummary(
                 uploadPlan.skippedFiles,
                 formatBytes(uploadPlan.skippedBytes),
               )}
-            </p>
+            </div>
           )}
-          <div className="mt-3 grid grid-cols-1 gap-2 sm:grid-cols-2">
-            {uploadPlan.groups.map((group) => (
-              <FilterGroupCard
-                key={group.category}
-                group={group}
-                checked={includedCategories.has(group.category)}
-                excludedExtensions={excludedExtensions}
-                disabled={running}
-                onToggleCategory={toggleCategory}
-                onToggleExtension={toggleExtension}
-              />
-            ))}
+          <div className="max-h-72 overflow-y-auto">
+            <table className="w-full table-fixed border-collapse">
+              <thead className="sticky top-0 bg-bg-subtle text-left text-[11px] text-fg-subtle">
+                <tr className="border-b border-border">
+                  <th className="w-8 px-3 py-1.5">
+                    <span className="sr-only">select</span>
+                  </th>
+                  <th className="px-1 py-1.5 font-medium">{t.dialogs.uploadFile}</th>
+                  <th className="w-20 px-2 py-1.5 font-medium">{t.dialogs.uploadType}</th>
+                  <th className="w-20 px-2 py-1.5 text-right font-medium">
+                    {t.dialogs.uploadSize}
+                  </th>
+                  <th className="w-20 px-2 py-1.5 text-right font-medium">
+                    {t.dialogs.uploadStatus}
+                  </th>
+                </tr>
+              </thead>
+              <tbody>
+                {items.map((it, i) => (
+                  <UploadRow
+                    key={i}
+                    item={it}
+                    index={i}
+                    running={running}
+                    onToggle={toggleItem}
+                  />
+                ))}
+              </tbody>
+            </table>
           </div>
         </div>
-      )}
-
-      {items.length > 0 && (
-        <ul className="mt-3 max-h-64 space-y-1 overflow-y-auto rounded-md border border-border bg-bg-subtle p-2 text-xs">
-          {items.map((it, i) => (
-            <UploadRow
-              key={i}
-              item={it}
-              skipped={
-                it.status === "queued"
-                && !shouldUploadItem(it, includedCategories, excludedExtensions)
-              }
-            />
-          ))}
-        </ul>
       )}
 
       <div className="mt-4 flex justify-end gap-2">
@@ -378,99 +450,165 @@ export function UploadDialog({ folderId, folderName, onClose, onUploaded }: {
   );
 }
 
-function FilterGroupCard({
+function CategoryToggle({
   group,
-  checked,
-  excludedExtensions,
+  disabled,
+  onToggle,
+}: {
+  group: UploadGroup;
+  disabled: boolean;
+  onToggle: (category: UploadCategory) => void;
+}) {
+  const { t } = useI18n();
+  const checked = group.selectedFiles > 0;
+  return (
+    <label
+      className={cn(
+        "flex cursor-pointer items-center gap-1.5 whitespace-nowrap text-fg-muted",
+        checked && "text-fg-base",
+      )}
+      title={t.dialogs.uploadCategorySummary(group.files, formatBytes(group.bytes))}
+    >
+      <input
+        type="checkbox"
+        checked={checked}
+        disabled={disabled}
+        onChange={() => onToggle(group.category)}
+        className="accent-accent"
+      />
+      <span>{t.dialogs.uploadCategories[group.category]}</span>
+    </label>
+  );
+}
+
+function UploadFilterPanel({
+  groups,
   disabled,
   onToggleCategory,
   onToggleExtension,
 }: {
-  group: UploadGroup;
-  checked: boolean;
-  excludedExtensions: Set<string>;
+  groups: UploadGroup[];
   disabled: boolean;
   onToggleCategory: (category: UploadCategory) => void;
-  onToggleExtension: (ext: string) => void;
+  onToggleExtension: (category: UploadCategory, ext: string) => void;
 }) {
   const { t } = useI18n();
   return (
-    <div className="rounded-md border border-border bg-bg-base p-2">
-      <label className="flex cursor-pointer items-start gap-2">
-        <input
-          type="checkbox"
-          checked={checked}
-          disabled={disabled}
-          onChange={() => onToggleCategory(group.category)}
-          className="mt-0.5 accent-accent"
-        />
-        <span className="min-w-0 flex-1">
-          <span className="block font-medium text-fg-base">
-            {t.dialogs.uploadCategories[group.category]}
-          </span>
-          <span className="block text-fg-muted">
-            {t.dialogs.uploadCategorySummary(group.files, formatBytes(group.bytes))}
-          </span>
-        </span>
-      </label>
-      {group.extensions.length > 0 && (
-        <div className="mt-2 flex flex-wrap gap-1">
-          {group.extensions.map((ext) => {
-            const excluded = excludedExtensions.has(ext.ext);
-            return (
+    <div
+      className={cn(
+        "absolute right-0 top-full z-50 mt-2 w-[360px] max-w-[calc(100vw-48px)]",
+        "rounded-md border border-border bg-bg-elevated p-3 shadow-xl",
+      )}
+    >
+      <div className="space-y-3">
+        {groups.map((group) => (
+          <div key={group.category}>
+            <div className="mb-1.5 flex items-center justify-between gap-2">
+              <span className="font-medium text-fg-base">
+                {t.dialogs.uploadCategories[group.category]}
+              </span>
               <button
-                key={ext.ext}
                 type="button"
                 disabled={disabled}
-                onClick={() => onToggleExtension(ext.ext)}
-                title={
-                  excluded
-                    ? t.dialogs.uploadIncludeExtension(ext.ext)
-                    : t.dialogs.uploadExcludeExtension(ext.ext)
-                }
-                className={cn(
-                  "rounded border px-1.5 py-0.5 text-[11px]",
-                  excluded
-                    ? "border-danger/50 bg-danger/10 text-danger"
-                    : "border-border text-fg-muted hover:border-accent hover:text-accent",
-                )}
+                onClick={() => onToggleCategory(group.category)}
+                className="rounded border border-border px-2 py-0.5 text-[11px] text-fg-muted hover:border-accent hover:text-accent disabled:opacity-50"
               >
-                {ext.ext} {ext.files}
+                {group.selectedFiles === group.files
+                  ? t.dialogs.uploadSelectNone
+                  : t.dialogs.uploadSelectAll}
               </button>
-            );
-          })}
-        </div>
-      )}
+            </div>
+            <div className="flex flex-wrap gap-1.5">
+              {group.extensions.map((ext) => {
+                const selected = ext.selectedFiles > 0;
+                return (
+                  <button
+                    key={ext.ext}
+                    type="button"
+                    disabled={disabled}
+                    onClick={() => onToggleExtension(group.category, ext.ext)}
+                    title={
+                      selected
+                        ? t.dialogs.uploadExcludeExtension(ext.ext)
+                        : t.dialogs.uploadIncludeExtension(ext.ext)
+                    }
+                    className={cn(
+                      "rounded border px-2 py-1 text-[11px] disabled:opacity-50",
+                      selected
+                        ? "border-accent/70 bg-accent-subtle text-accent"
+                        : "border-border bg-bg-muted text-fg-subtle",
+                    )}
+                  >
+                    {ext.ext} {ext.files}
+                  </button>
+                );
+              })}
+            </div>
+          </div>
+        ))}
+      </div>
     </div>
   );
 }
 
-function UploadRow({ item, skipped }: { item: UploadItem; skipped: boolean }) {
+function UploadRow({
+  item,
+  index,
+  running,
+  onToggle,
+}: {
+  item: UploadItem;
+  index: number;
+  running: boolean;
+  onToggle: (index: number) => void;
+}) {
   const { t } = useI18n();
   const pct = item.file.size > 0 ? Math.round((item.loaded / item.file.size) * 100) : 0;
   const prefix = item.relDirs.length ? item.relDirs.join("/") + "/" : "";
+  const category = categoryForFile(item.file);
+  const ext = extensionForFile(item.file);
+  const skipped = item.status === "queued" && !item.selected;
   return (
-    <li className="flex items-center gap-2">
-      <span className="flex-1 truncate" title={prefix + item.file.name}>
-        {prefix && <span className="text-fg-subtle">{prefix}</span>}
-        {item.file.name}
-      </span>
-      <span className="w-12 text-right text-fg-subtle">
+    <tr className={cn("border-b border-border last:border-0", skipped && "text-fg-subtle")}>
+      <td className="px-3 py-1.5">
+        <input
+          type="checkbox"
+          checked={item.selected}
+          disabled={running || item.status !== "queued"}
+          onChange={() => onToggle(index)}
+          className="accent-accent"
+        />
+      </td>
+      <td className="min-w-0 px-1 py-1.5">
+        <div className="truncate" title={prefix + item.file.name}>
+          {prefix && <span className="text-fg-subtle">{prefix}</span>}
+          {item.file.name}
+        </div>
+        {item.renamedTo && (
+          <div className="truncate text-[11px] text-fg-subtle" title={item.renamedTo}>
+            {t.dialogs.renamedTo(item.renamedTo)}
+          </div>
+        )}
+        {item.err && (
+          <div className="truncate text-[11px] text-danger" title={item.err}>
+            {item.err}
+          </div>
+        )}
+      </td>
+      <td className="px-2 py-1.5 text-fg-muted" title={t.dialogs.uploadCategories[category]}>
+        {ext}
+      </td>
+      <td className="px-2 py-1.5 text-right text-fg-muted">
+        {formatBytes(item.file.size)}
+      </td>
+      <td className="px-2 py-1.5 text-right text-fg-muted">
         {item.status === "uploading" ? `${pct}%`
          : item.status === "done" ? "done"
          : item.status === "error" ? "!"
          : skipped ? t.dialogs.skipped
          : "-"}
-      </span>
-      {item.renamedTo && (
-        <span className="truncate text-fg-subtle" title={t.dialogs.renamedTo(item.renamedTo)}>
-          {t.dialogs.renamedTo(item.renamedTo)}
-        </span>
-      )}
-      {item.err && (
-        <span className="truncate text-danger" title={item.err}>{item.err}</span>
-      )}
-    </li>
+      </td>
+    </tr>
   );
 }
 
@@ -480,11 +618,7 @@ function updateAt<T>(arr: T[], i: number, patch: Partial<T>): T[] {
   return next;
 }
 
-function summarizeUploadPlan(
-  items: UploadItem[],
-  includedCategories: Set<UploadCategory>,
-  excludedExtensions: Set<string>,
-) {
+function summarizeUploadPlan(items: UploadItem[]) {
   const groups = new Map<UploadCategory, UploadGroup>();
   let selectedFiles = 0;
   let selectedBytes = 0;
@@ -502,7 +636,12 @@ function summarizeUploadPlan(
     });
   }
 
-  const extMaps = new Map<UploadCategory, Map<string, { files: number; bytes: number }>>();
+  const extMaps = new Map<UploadCategory, Map<string, {
+    files: number;
+    bytes: number;
+    selectedFiles: number;
+    selectedBytes: number;
+  }>>();
   for (const item of items) {
     const category = categoryForFile(item.file);
     const ext = extensionForFile(item.file);
@@ -511,20 +650,27 @@ function summarizeUploadPlan(
     group.bytes += item.file.size;
     if (!extMaps.has(category)) extMaps.set(category, new Map());
     const extMap = extMaps.get(category)!;
-    const extStat = extMap.get(ext) ?? { files: 0, bytes: 0 };
+    const extStat = extMap.get(ext) ?? {
+      files: 0,
+      bytes: 0,
+      selectedFiles: 0,
+      selectedBytes: 0,
+    };
     extStat.files += 1;
     extStat.bytes += item.file.size;
-    extMap.set(ext, extStat);
 
-    if (shouldUploadItem(item, includedCategories, excludedExtensions)) {
+    if (item.selected) {
       selectedFiles += 1;
       selectedBytes += item.file.size;
       group.selectedFiles += 1;
       group.selectedBytes += item.file.size;
+      extStat.selectedFiles += 1;
+      extStat.selectedBytes += item.file.size;
     } else {
       skippedFiles += 1;
       skippedBytes += item.file.size;
     }
+    extMap.set(ext, extStat);
   }
 
   for (const [category, extMap] of extMaps) {
@@ -542,16 +688,6 @@ function summarizeUploadPlan(
     skippedFiles,
     skippedBytes,
   };
-}
-
-function shouldUploadItem(
-  item: UploadItem,
-  includedCategories: Set<UploadCategory>,
-  excludedExtensions: Set<string>,
-): boolean {
-  const category = categoryForFile(item.file);
-  const ext = extensionForFile(item.file);
-  return includedCategories.has(category) && !excludedExtensions.has(ext);
 }
 
 function categoryForFile(file: File): UploadCategory {
@@ -634,8 +770,10 @@ function ModalShell({ title, onClose, children, wide }: {
       <div
         onClick={(e) => e.stopPropagation()}
         className={cn(
-          "rounded-lg border border-border bg-bg-elevated shadow-2xl",
-          wide ? "w-[480px]" : "w-[360px]",
+          "flex max-h-[calc(100vh-32px)] flex-col overflow-hidden rounded-lg border border-border bg-bg-elevated shadow-2xl",
+          wide
+            ? "w-[900px] max-w-[calc(100vw-32px)]"
+            : "w-[360px] max-w-[calc(100vw-32px)]",
         )}
       >
         <header className="flex items-center justify-between border-b border-border px-4 py-2.5 text-sm font-medium">
@@ -646,7 +784,7 @@ function ModalShell({ title, onClose, children, wide }: {
             <X size={14} />
           </button>
         </header>
-        <div className="p-4">{children}</div>
+        <div className="overflow-y-auto p-4">{children}</div>
       </div>
     </div>
   );
@@ -665,7 +803,13 @@ async function walkEntry(
 ): Promise<void> {
   if ((entry as FileSystemFileEntry).isFile) {
     const file = await fileFromEntry(entry as FileSystemFileEntry);
-    out.push({ file, relDirs: parentDirs, loaded: 0, status: "queued" });
+    out.push({
+      file,
+      relDirs: parentDirs,
+      loaded: 0,
+      selected: DEFAULT_INCLUDED_CATEGORIES.includes(categoryForFile(file)),
+      status: "queued",
+    });
     return;
   }
   if ((entry as FileSystemDirectoryEntry).isDirectory) {

--- a/desktop/src/lib/i18n.ts
+++ b/desktop/src/lib/i18n.ts
@@ -261,6 +261,12 @@ const en = {
       `${selected} to upload · ${skipped} skipped`,
     uploadSkippedSummary: (files: number, size: string) =>
       `Skipping ${files} file(s), ${size}.`,
+    uploadSelectAll: "All",
+    uploadSelectNone: "None",
+    uploadFile: "File",
+    uploadType: "Type",
+    uploadSize: "Size",
+    uploadStatus: "Status",
     uploadCategories: {
       documents: "Documents",
       pdfs: "PDFs",
@@ -867,6 +873,12 @@ const zh: I18nStrings = {
       `将上传 ${selected} 个 · 跳过 ${skipped} 个`,
     uploadSkippedSummary: (files: number, size: string) =>
       `已跳过 ${files} 个文件，${size}。`,
+    uploadSelectAll: "全选",
+    uploadSelectNone: "全不选",
+    uploadFile: "文件",
+    uploadType: "类型",
+    uploadSize: "大小",
+    uploadStatus: "状态",
     uploadCategories: {
       documents: "文档",
       pdfs: "PDF",

--- a/src/marginalia/db/bootstrap.py
+++ b/src/marginalia/db/bootstrap.py
@@ -275,6 +275,45 @@ def _ensure_journal_invalidation(bind) -> None:
     _ensure_query_performance_indexes(bind)
 
 
+def _reconcile_dead_ingest_files(bind) -> None:
+    """Repair files left pending/processing after terminal ingest task death."""
+    inspector = sa.inspect(bind)
+    existing_tables = set(inspector.get_table_names())
+    if not {"files", "tasks"}.issubset(existing_tables):
+        return
+
+    now = datetime.now(timezone.utc)
+    if bind.dialect.name == "postgresql":
+        file_id_expr = "payload ->> 'file_id'"
+    else:
+        file_id_expr = "json_extract(payload, '$.file_id')"
+
+    bind.execute(
+        sa.text(f"""
+            UPDATE files
+            SET ingest_status = 'failed',
+                updated_at = :now
+            WHERE deleted_at IS NULL
+              AND ingest_status IN ('pending', 'processing')
+              AND EXISTS (
+                  SELECT 1
+                  FROM tasks dead
+                  WHERE dead.kind = 'ingest_file'
+                    AND dead.status = 'dead'
+                    AND {file_id_expr.replace('payload', 'dead.payload')} = files.id
+              )
+              AND NOT EXISTS (
+                  SELECT 1
+                  FROM tasks active
+                  WHERE active.kind = 'ingest_file'
+                    AND active.status IN ('pending', 'running')
+                    AND {file_id_expr.replace('payload', 'active.payload')} = files.id
+              )
+        """),
+        {"now": now},
+    )
+
+
 def _sqlite_supports_metadata_fts(bind) -> bool:
     if bind.dialect.name != "sqlite":
         return False
@@ -738,6 +777,7 @@ POST_BASELINE_SHIMS: tuple[tuple[str, Callable[[Any], None]], ...] = (
     ("0010_entry_metadata_fts_description", _ensure_entry_metadata_fts_description),
     ("0011_postgres_metadata_fts", _ensure_postgres_metadata_fts_indexes),
     ("0012_journal_invalidation", _ensure_journal_invalidation),
+    ("0013_reconcile_dead_ingest_files", _reconcile_dead_ingest_files),
 )
 
 ALEMBIC_HEAD_REVISION = POST_BASELINE_SHIMS[-1][0]

--- a/src/marginalia/repositories/files.py
+++ b/src/marginalia/repositories/files.py
@@ -4,6 +4,8 @@ Caller owns the transaction.
 """
 from __future__ import annotations
 
+from datetime import datetime
+
 from sqlalchemy import delete, func, or_, select, update
 from sqlalchemy.ext.asyncio import AsyncSession
 
@@ -69,6 +71,27 @@ async def update_storage_key(
         .where(File.id == file_id)
         .values(storage_key=storage_key)
     )
+
+
+async def mark_ingest_failed(
+    db: AsyncSession, *, file_id: str, now: datetime,
+) -> bool:
+    """Mark a live file as failed if ingest has not completed.
+
+    Used when an ingest_file task reaches the terminal dead state outside the
+    handler's normal exception path, e.g. stale-task recovery or a runner-level
+    configuration failure.
+    """
+    result = await db.execute(
+        update(File)
+        .where(
+            File.id == file_id,
+            File.deleted_at.is_(None),
+            File.ingest_status.in_(("pending", "processing")),
+        )
+        .values(ingest_status="failed", updated_at=now)
+    )
+    return bool(result.rowcount or 0)
 
 
 async def list_live_ids(

--- a/src/marginalia/repositories/tasks.py
+++ b/src/marginalia/repositories/tasks.py
@@ -139,6 +139,22 @@ async def mark_pending_dead_by_kinds(
     return int(result.rowcount or 0)
 
 
+async def list_pending_by_kinds(
+    db: AsyncSession, *, kinds: Sequence[str],
+) -> list[Task]:
+    """Pending task rows for the given kinds before a bulk terminal update."""
+    if not kinds:
+        return []
+    rows = (
+        await db.execute(
+            select(Task)
+            .where(Task.status == "pending", Task.kind.in_(list(kinds)))
+            .order_by(Task.created_at.asc())
+        )
+    ).scalars().all()
+    return list(rows)
+
+
 async def reschedule_for_retry(
     db: AsyncSession,
     *,

--- a/src/marginalia/services/ingest_status.py
+++ b/src/marginalia/services/ingest_status.py
@@ -1,0 +1,49 @@
+"""Helpers for keeping file ingest state aligned with task outcomes."""
+from __future__ import annotations
+
+from datetime import datetime, timezone
+from typing import Any, Mapping
+
+from sqlalchemy.ext.asyncio import AsyncSession
+
+from marginalia.repositories import audit_events as audit_events_repo
+from marginalia.repositories import files as files_repo
+from marginalia.tasks.kinds import KIND_INGEST_FILE
+
+
+def _utcnow() -> datetime:
+    return datetime.now(timezone.utc)
+
+
+async def mark_file_failed_for_dead_ingest_task(
+    session: AsyncSession,
+    *,
+    task_id: str,
+    kind: str,
+    payload: Mapping[str, Any] | None,
+    reason: str,
+) -> bool:
+    """Mirror a terminal ingest_file task failure onto files.ingest_status."""
+    if kind != KIND_INGEST_FILE or not isinstance(payload, Mapping):
+        return False
+    file_id = payload.get("file_id")
+    if not isinstance(file_id, str) or not file_id:
+        return False
+
+    now = _utcnow()
+    changed = await files_repo.mark_ingest_failed(
+        session, file_id=file_id, now=now,
+    )
+    if changed:
+        await audit_events_repo.append(
+            session,
+            kind="ingest_status_changed",
+            task_id=task_id,
+            occurred_at=now,
+            payload={
+                "file_id": file_id,
+                "status": "failed",
+                "reason": reason[:500],
+            },
+        )
+    return changed

--- a/src/marginalia/tasks/handlers/recover_stuck_tasks.py
+++ b/src/marginalia/tasks/handlers/recover_stuck_tasks.py
@@ -24,6 +24,7 @@ from typing import Any, Mapping
 from marginalia.repositories import audit_events as audit_events_repo
 from marginalia.db.session import session_scope
 from marginalia.repositories import tasks as tasks_repo
+from marginalia.services.ingest_status import mark_file_failed_for_dead_ingest_task
 from marginalia.tasks.kinds import KIND_RECOVER_STUCK_TASKS, task_handler
 
 log = logging.getLogger(__name__)
@@ -52,6 +53,13 @@ async def handle_recover_stuck_tasks(payload: Mapping[str, Any]) -> None:
                     task_id=t.id,
                     now=now,
                     error="recover_stuck_tasks: lease expired beyond max_attempts",
+                )
+                await mark_file_failed_for_dead_ingest_task(
+                    session,
+                    task_id=t.id,
+                    kind=t.kind,
+                    payload=t.payload or {},
+                    reason="recover_stuck_tasks: lease expired beyond max_attempts",
                 )
                 await audit_events_repo.append(
                     session,

--- a/src/marginalia/tasks/runner.py
+++ b/src/marginalia/tasks/runner.py
@@ -11,6 +11,7 @@ from marginalia.config import LlmConfigError, Settings, get_settings, validate_l
 from marginalia.db.session import session_scope
 from marginalia.repositories import tasks as tasks_repo
 from marginalia.repositories import task_outcomes as outcomes_repo
+from marginalia.services.ingest_status import mark_file_failed_for_dead_ingest_task
 from marginalia.tasks import handlers as _handlers_pkg  # noqa: F401  (register)
 from marginalia.tasks.kinds import LLM_DEPENDENT_KINDS, get_handler
 from marginalia.tasks.usage import (
@@ -73,12 +74,24 @@ class TaskRunner:
         if self._has_llm_key():
             return
         async with session_scope() as session:
+            pending = await tasks_repo.list_pending_by_kinds(
+                session,
+                kinds=sorted(LLM_DEPENDENT_KINDS),
+            )
             n = await tasks_repo.mark_pending_dead_by_kinds(
                 session,
                 kinds=sorted(LLM_DEPENDENT_KINDS),
                 now=_now(),
                 error=_NO_LLM_KEY_ERROR,
             )
+            for task in pending:
+                await mark_file_failed_for_dead_ingest_task(
+                    session,
+                    task_id=task.id,
+                    kind=task.kind,
+                    payload=task.payload or {},
+                    reason=_NO_LLM_KEY_ERROR,
+                )
             await session.commit()
         if n:
             log.warning(
@@ -263,6 +276,7 @@ class TaskRunner:
         self, task_id: str, attempts: int, max_attempts: int, error: str
     ) -> bool:
         async with session_scope() as session:
+            task = await tasks_repo.get(session, task_id)
             if attempts >= max_attempts:
                 changed = await tasks_repo.mark_dead(
                     session,
@@ -271,6 +285,14 @@ class TaskRunner:
                     error=error,
                     worker_id=self.worker_id,
                 )
+                if changed and task is not None:
+                    await mark_file_failed_for_dead_ingest_task(
+                        session,
+                        task_id=task.id,
+                        kind=task.kind,
+                        payload=task.payload or {},
+                        reason=error,
+                    )
             else:
                 changed = await tasks_repo.reschedule_for_retry(
                     session,

--- a/tests/test_ingest_status_reconciliation.py
+++ b/tests/test_ingest_status_reconciliation.py
@@ -1,0 +1,144 @@
+from __future__ import annotations
+
+from datetime import datetime, timezone
+
+import pytest
+from sqlalchemy import create_engine, select
+from sqlalchemy.ext.asyncio import async_sessionmaker, create_async_engine
+
+from marginalia.db.bootstrap import _reconcile_dead_ingest_files
+from marginalia.db.models import AuditEvent, Base, File, Task
+from marginalia.services.ingest_status import mark_file_failed_for_dead_ingest_task
+from marginalia.tasks.kinds import KIND_INGEST_FILE
+from marginalia.utils.ids import new_id
+
+
+def _now() -> datetime:
+    return datetime.now(timezone.utc)
+
+
+def _file(file_id: str, *, status: str = "processing") -> File:
+    now = _now()
+    return File(
+        id=file_id,
+        storage_key=f"store/{file_id}",
+        sha256=file_id.replace("-", "")[:64].ljust(64, "0"),
+        size_bytes=10,
+        mime_type="text/plain",
+        original_ext=".txt",
+        kind=None,
+        summary=None,
+        description=None,
+        extra=None,
+        ingest_status=status,
+        ingested_at=None,
+        deleted_at=None,
+        created_at=now,
+        updated_at=now,
+    )
+
+
+def _task(
+    task_id: str,
+    *,
+    file_id: str,
+    status: str,
+    kind: str = KIND_INGEST_FILE,
+) -> Task:
+    now = _now()
+    return Task(
+        id=task_id,
+        kind=kind,
+        payload={"file_id": file_id},
+        dedup_key=f"ingest_file:{file_id}",
+        status=status,
+        priority=100,
+        attempts=1,
+        max_attempts=5,
+        last_error="boom" if status == "dead" else None,
+        scheduled_at=now,
+        lease_expires_at=None,
+        last_heartbeat_at=None,
+        locked_by=None,
+        created_at=now,
+        started_at=now if status in {"running", "dead", "done"} else None,
+        finished_at=now if status in {"dead", "done"} else None,
+    )
+
+
+@pytest.mark.asyncio
+async def test_dead_ingest_task_marks_file_failed_and_audits(tmp_path) -> None:
+    engine = create_async_engine(f"sqlite+aiosqlite:///{tmp_path / 'state.db'}")
+    factory = async_sessionmaker(engine, expire_on_commit=False, autoflush=False)
+    file_id = new_id()
+    task_id = new_id()
+
+    try:
+        async with engine.begin() as conn:
+            await conn.run_sync(Base.metadata.create_all)
+
+        async with factory() as session:
+            session.add(_file(file_id))
+            await session.commit()
+
+        async with factory() as session:
+            changed = await mark_file_failed_for_dead_ingest_task(
+                session,
+                task_id=task_id,
+                kind=KIND_INGEST_FILE,
+                payload={"file_id": file_id},
+                reason="task exploded",
+            )
+            await session.commit()
+            assert changed is True
+
+        async with factory() as session:
+            file_row = await session.get(File, file_id)
+            assert file_row is not None
+            assert file_row.ingest_status == "failed"
+
+            event = (
+                await session.execute(
+                    select(AuditEvent)
+                    .where(AuditEvent.kind == "ingest_status_changed")
+                    .order_by(AuditEvent.occurred_at.desc())
+                )
+            ).scalar_one()
+            assert event.task_id == task_id
+            assert event.payload["file_id"] == file_id
+            assert event.payload["status"] == "failed"
+            assert event.payload["reason"] == "task exploded"
+    finally:
+        await engine.dispose()
+
+
+def test_bootstrap_reconciles_dead_ingest_files_without_active_task(tmp_path) -> None:
+    engine = create_engine(f"sqlite:///{tmp_path / 'state.db'}")
+    dead_only = new_id()
+    active_too = new_id()
+    no_dead = new_id()
+
+    try:
+        Base.metadata.create_all(engine)
+        from sqlalchemy.orm import Session
+
+        with Session(engine) as session:
+            session.add_all([
+                _file(dead_only),
+                _file(active_too),
+                _file(no_dead),
+                _task(new_id(), file_id=dead_only, status="dead"),
+                _task(new_id(), file_id=active_too, status="dead"),
+                _task(new_id(), file_id=active_too, status="running"),
+            ])
+            session.commit()
+
+        with engine.begin() as conn:
+            _reconcile_dead_ingest_files(conn)
+
+        with Session(engine) as session:
+            assert session.get(File, dead_only).ingest_status == "failed"
+            assert session.get(File, active_too).ingest_status == "processing"
+            assert session.get(File, no_dead).ingest_status == "processing"
+    finally:
+        engine.dispose()


### PR DESCRIPTION
## Summary

- Mark files as `failed` whenever an `ingest_file` task reaches terminal `dead`, including runner failures, no-LLM startup sweeps, and stale-task recovery.
- Add an idempotent bootstrap/alembic repair for existing files left in `pending`/`processing` after a dead ingest task with no active replacement.
- Replace the upload folder filter cards with a downloader-style file selection table: per-file checkboxes, top-level type toggles, and a filter popover grouped by type and extension.
- Keep videos excluded by default while documents/images/audio/archives/PDFs/unknown files start selected.

## Validation

- `python -B -m pytest tests/test_ingest_status_reconciliation.py tests/test_ingest_file_unit.py tests/test_reprocess_e2e.py -q`
- `python -B -m pytest tests/test_folders_ingest_status_e2e.py -q`
- `npm run lint` in `desktop`
- `git diff --check`

## Local data repair

Applied the new bootstrap repair to the local database. Current live file statuses are `done=39`, `failed=4`, `processing=0`.